### PR TITLE
DC-333: New index for status to improve metrics query

### DIFF
--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
@@ -73,13 +73,12 @@ abstract class WorkItemRepository[T, ID](collectionName: String,
     Index(
       key = Seq(workItemFields.status -> IndexType.Ascending, workItemFields.availableAt -> IndexType.Ascending),
       unique = false,
+      background = true),
+    Index(
+      key = Seq(workItemFields.status -> IndexType.Ascending),
+      unique = false,
       background = true)
   )
-
-  private[workitem] val receivedAtIndex = Index(
-    key = Seq(workItemFields.status -> IndexType.Ascending, workItemFields.receivedAt -> IndexType.Ascending),
-    unique = false,
-    background = true)
 
   private def toDo(item: T): ProcessingStatus = ToDo
 

--- a/src/test/scala/uk/gov/hmrc/workitem/WorkItemRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WorkItemRepositorySpec.scala
@@ -281,7 +281,7 @@ class WorkItemRepositorySpec extends WordSpec
     "verify number of indexes created" in {
       repo.collection.indexesManager.dropAll().futureValue
       repo.ensureIndexes.futureValue
-      repo.collection.indexesManager.list().futureValue.size should be (2 + 1) //_id index is created by default
+      repo.collection.indexesManager.list().futureValue.size should be (3 + 1) //_id index is created by default
     }
 
     "count the number of items in a specific state" in {


### PR DESCRIPTION
The metrics using status only appears in the slow-mongo queries dashboard. Hence, adding a new index with status only to improve the performance of this metric query.
