### PR TITLE
DC-485 use the module name for the work item gauge instead of the col…

### DIFF
--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItemModuleRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItemModuleRepository.scala
@@ -44,6 +44,8 @@ abstract class WorkItemModuleRepository[T](
 
   override lazy val workItemFields: WorkItemFieldNames = WorkItemModuleRepository.workItemFieldNames(moduleName)
 
+  override lazy val workItemGaugeCollectionName = moduleName
+
 }
 
 object WorkItemModuleRepository {

--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
@@ -44,6 +44,8 @@ abstract class WorkItemRepository[T, ID](collectionName: String,
 
   def inProgressRetryAfterProperty: String
 
+  def workItemGaugeCollectionName = collectionName
+
   private implicit val dateFormats = ReactiveMongoFormats.dateTimeFormats
   private implicit val bsonFormatter = BSONFormats.BSONDocumentFormat
 

--- a/src/main/scala/uk/gov/hmrc/workitem/metrics/WorkItemGauge.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/metrics/WorkItemGauge.scala
@@ -57,6 +57,6 @@ trait WorkItemMetrics {
     ProcessingStatus.processingStatuses.map(WorkItemStatusGauge).toSeq :+ TotalWorkItemsGauge()
 
   gauges map { gauge =>
-    MetricsRegistry.defaultRegistry.register(s"${repository.collection.name}.${gauge.name}", gauge)
+    MetricsRegistry.defaultRegistry.register(s"${repository.workItemGaugeCollectionName}.${gauge.name}", gauge)
   }
 }

--- a/src/test/scala/uk/gov/hmrc/workitem/WorkItemModuleRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WorkItemModuleRepositorySpec.scala
@@ -80,6 +80,10 @@ class WorkItemModuleRepositorySpec
 
     }
 
+    "use the module name as the gauge name" in {
+      repo.workItemGaugeCollectionName should be ("testModule")
+    }
+
     "change state successfully" in {
       val _id = BSONObjectID.generate
       val documentCreationTime = timeSource.now


### PR DESCRIPTION
 use the module name for the work item gauge instead of the collection name, which is confusing. Also, it means you can now gauge multiple 'modules' on the same collection.
