### PR TITLE
DC-510: Local Metrics Storage

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -35,7 +35,8 @@ object HmrcBuild extends Build {
     pegdown     % "test",
     scalacheck  % "test",
     `play-test` % "test",
-    `reactivemongo-test` % "test"
+    `reactivemongo-test` % "test",
+    hmrcTest
   )
 
 
@@ -70,6 +71,7 @@ private object BuildDependencies {
 
   val `metrics-play`         = "com.kenshoo" %% "metrics-play" % "2.3.0_0.1.8"
   val metrics                = "com.codahale.metrics" % "metrics-graphite" % "3.0.2"
+  val hmrcTest               = "uk.gov.hmrc"  %% "hmrctest" % "1.8.0" % "test"
 }
 
 object Collaborators {

--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
@@ -176,9 +176,6 @@ abstract class WorkItemRepository[T, ID](collectionName: String,
   def count(state: ProcessingStatus)(implicit ec: ExecutionContext): Future[Int] = collection.db.command(
     Count(collection.name, Some(BSONDocument(workItemFields.status -> state.name))), ReadPreference.secondaryPreferred)
 
-  override def count(implicit ec: ExecutionContext): Future[Int] =
-    collection.db.command(Count(collection.name), ReadPreference.secondaryPreferred)
-
   private def setStatusOperation(newStatus: ProcessingStatus, availableAt: Option[DateTime]): JsObject = {
     val fields = Json.obj(
       workItemFields.status -> newStatus,

--- a/src/main/scala/uk/gov/hmrc/workitem/metrics/WorkItemGauge.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/metrics/WorkItemGauge.scala
@@ -18,48 +18,56 @@ package uk.gov.hmrc.workitem.metrics
 
 import com.codahale.metrics.Gauge
 import com.kenshoo.play.metrics.MetricsRegistry
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json._
 import reactivemongo.api.DB
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.workitem.{ProcessingStatus, WorkItemRepository}
-import reactivemongo.json.ImplicitBSONHandlers._
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
+import reactivemongo.json.ImplicitBSONHandlers._
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
-case class WorkItemGauge(status: ProcessingStatus, itemRepository: WorkItemRepository[_, _], metrics: MetricsRepo, atMost: Duration)
+case class WorkItemGauge(status: ProcessingStatus, metrics: MetricsRepo, atMost: Duration)
                         (implicit ec: ExecutionContext) extends Gauge[Int] {
-  def refresh(): Future[Int] = run().map { _.fold(0) { _.value } }
-
-  private def run(): Future[Option[MetricsStorage]] =
-    itemRepository.count(status).flatMap { value =>
-      metrics.collection.findAndUpdate(
-        selector = Json.obj("key" -> status.name),
-        update = Json.obj("key" -> status.name, "value" -> value ),
-        upsert = true,
-        fetchNewObject = true
-      )
-    }.map { _.result[MetricsStorage] }
-
-  override def getValue(): Int = Await.result(
-    metrics.find("key" -> status).map(_.foldRight(0) { (ms, acc) => ms.value + acc }), atMost
-  )
+  override def getValue(): Int = ???
+    /*
+    Await.result(
+    metrics.find("key" -> status.n).map(_.foldRight(0) { (ms, acc) => ms.value + acc }), atMost
+  )*/
 }
+
 
 object WorkItemGauge {
 
+  def reset(gauges: List[WorkItemGauge], itemRepository: WorkItemRepository[_, _], metricsDB: MetricsRepo)
+           (implicit ec: ExecutionContext) =
+    Future.traverse(gauges) { gauge =>
+      itemRepository.count(gauge.status).map { (gauge.status.name, _) }
+    }.flatMap { keyValues => metricsDB.reset(MetricsStorage(values = keyValues.toMap)) }
+
   def createGauges(repository: WorkItemRepository[_,_], metrics: MetricsRepo, awaitTime: Duration)
                   (implicit ec: ExecutionContext): List[WorkItemGauge] =
-    ProcessingStatus.processingStatuses.map(WorkItemGauge(_, repository, metrics, awaitTime)).map { gauge =>
+    ProcessingStatus.processingStatuses.map(WorkItemGauge(_, metrics, awaitTime)).map { gauge =>
       MetricsRegistry.defaultRegistry.register(s"${repository.workItemGaugeCollectionName}.${gauge.status.name}", gauge)
     }.toList
-
 }
 
-case class MetricsStorage(key: String, value: Int)
+case class MetricsStorage(id: BSONObjectID = BSONObjectID.generate, values: Map[String, Int])
 object MetricsStorage {
-  implicit val format: Format[MetricsStorage] = Json.format[MetricsStorage]
+  implicit val reads: Reads[MetricsStorage] = ???
+  implicit val writes: Writes[MetricsStorage] = ???
+  implicit val format: Format[MetricsStorage] = Format.apply(reads, writes)
 }
 
-class MetricsRepo(collectionName: String)(implicit mongo: () => DB) extends ReactiveRepository[MetricsStorage, BSONObjectID](collectionName, mongo, MetricsStorage.format)
+class MetricsRepo(collectionName: String)(implicit mongo: () => DB) extends ReactiveRepository[MetricsStorage, BSONObjectID](collectionName, mongo, MetricsStorage.format) {
+
+  def reset(storage: MetricsStorage)(implicit executionContext: ExecutionContext): Future[Option[MetricsStorage]] =
+    collection.findAndUpdate(
+      selector = Json.obj("_id" -> Json.obj("$exists" -> true)),
+      update = Json.toJson(storage),
+      upsert = true,
+      fetchNewObject = true
+    ).map(_.result)
+}

--- a/src/main/scala/uk/gov/hmrc/workitem/status.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/status.scala
@@ -38,14 +38,14 @@ object ProcessingStatus {
   val processingStatuses: Set[ProcessingStatus] = Set(ToDo, InProgress, Succeeded, Failed, PermanentlyFailed, Ignored, Duplicate, Deferred, Cancelled)
   val nameToStatus:Map[String,ProcessingStatus] = processingStatuses.map(s => (s.name, s)).toMap
 
-  implicit val read = new Reads[ProcessingStatus] {
+  implicit val read: Reads[ProcessingStatus] = new Reads[ProcessingStatus] {
     override def reads(json: JsValue): JsResult[ProcessingStatus] = json match {
       case JsString(status) if nameToStatus.contains(status) => JsSuccess(nameToStatus(status))
       case other => JsError("Could not convert to ProcessingStatus from " + other)
     }
   }
 
-  implicit val write = new Writes[ProcessingStatus] {
+  implicit val write: Writes[ProcessingStatus] = new Writes[ProcessingStatus] {
     override def writes(p: ProcessingStatus): JsValue = JsString(p.name)
   }
 

--- a/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
@@ -24,6 +24,7 @@ import play.api.libs.json.Json
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.MongoSpecSupport
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+import uk.gov.hmrc.workitem.metrics.MetricsRepo
 
 trait TimeSource {
 
@@ -94,9 +95,12 @@ trait WithWorkItemRepository
     }
   }
 
+  lazy val metricsRepo: MetricsRepo = new MetricsRepo(collectionName = "metrics")
+
   protected override def beforeEach() {
     import scala.concurrent.ExecutionContext.Implicits.global
     repo.removeAll().futureValue
+    metricsRepo.removeAll().futureValue
   }
 
   val today = LocalDate.now(ISOChronology.getInstanceUTC)

--- a/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.Json
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.MongoSpecSupport
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
-import uk.gov.hmrc.workitem.metrics.MetricsRepo
+import uk.gov.hmrc.workitem.metrics.MongoMetricsRepo
 
 trait TimeSource {
 
@@ -95,7 +95,7 @@ trait WithWorkItemRepository
     }
   }
 
-  lazy val metricsRepo: MetricsRepo = new MetricsRepo(collectionName = "metrics")
+  lazy val metricsRepo: MongoMetricsRepo = new MongoMetricsRepo(collectionName = "metrics")
 
   protected override def beforeEach() {
     import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
@@ -73,8 +73,9 @@ trait WithWorkItemRepository
   import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.objectIdFormats
   implicit val eif = uk.gov.hmrc.workitem.ExampleItem.formats
 
-  lazy val repo = new WorkItemRepository[ExampleItem, BSONObjectID](
-    collectionName = "items",
+  def exampleItemRepository(collectionName: String) =
+    new WorkItemRepository[ExampleItem, BSONObjectID](
+    collectionName = collectionName,
     mongo = mongo,
     itemFormat = WorkItem.workItemMongoFormat[ExampleItem]) {
 
@@ -93,6 +94,8 @@ trait WithWorkItemRepository
       val failureCount = "failureCount"
     }
   }
+
+  lazy val repo = exampleItemRepository("items")
 
   lazy val metricsRepo: MongoMetricsRepo = new MongoMetricsRepo
 

--- a/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
@@ -70,7 +70,6 @@ trait WithWorkItemRepository
   with TimeSource {
   this: Suite =>
 
-
   import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.objectIdFormats
   implicit val eif = uk.gov.hmrc.workitem.ExampleItem.formats
 
@@ -95,7 +94,7 @@ trait WithWorkItemRepository
     }
   }
 
-  lazy val metricsRepo: MongoMetricsRepo = new MongoMetricsRepo(collectionName = "metrics")
+  lazy val metricsRepo: MongoMetricsRepo = new MongoMetricsRepo
 
   protected override def beforeEach() {
     import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/uk/gov/hmrc/workitem/metrics/MetricsRepoSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/metrics/MetricsRepoSpec.scala
@@ -1,23 +1,49 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.workitem.metrics
 
-import org.scalatest.LoneElement
+import org.scalatest.{BeforeAndAfterEach, LoneElement}
 import org.scalatest.concurrent.ScalaFutures
 import uk.gov.hmrc.mongo.MongoSpecSupport
 import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.workitem.ToDo
+
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits._
 
-class MetricsRepoSpec extends UnitSpec with MongoSpecSupport with ScalaFutures with LoneElement {
+class MetricsRepoSpec extends UnitSpec with MongoSpecSupport with ScalaFutures with LoneElement with BeforeAndAfterEach {
+
   override implicit val patienceConfig = PatienceConfig(timeout = 30 seconds, interval = 100 millis)
 
   lazy val metricsRepo = new MongoMetricsRepo(databaseName)
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    metricsRepo.removeAll().futureValue
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    metricsRepo.removeAll().futureValue
+  }
+
   "reset" should {
-    "store the provided MetricsStorage instance with the 'counts' key" in {
-      val storage = MetricsStorage(
-        Map(ToDo.name -> 5)
-      )
+    "store the provided MetricsStorage instance with the 'name' key" in {
+      val storage = MetricsCount(ToDo.name, 5)
 
       metricsRepo.reset(storage).futureValue
 

--- a/src/test/scala/uk/gov/hmrc/workitem/metrics/MetricsRepoSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/metrics/MetricsRepoSpec.scala
@@ -1,0 +1,28 @@
+package uk.gov.hmrc.workitem.metrics
+
+import org.scalatest.LoneElement
+import org.scalatest.concurrent.ScalaFutures
+import uk.gov.hmrc.mongo.MongoSpecSupport
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.workitem.ToDo
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits._
+
+class MetricsRepoSpec extends UnitSpec with MongoSpecSupport with ScalaFutures with LoneElement {
+  override implicit val patienceConfig = PatienceConfig(timeout = 30 seconds, interval = 100 millis)
+
+  lazy val metricsRepo = new MongoMetricsRepo(databaseName)
+
+  "reset" should {
+    "store the provided MetricsStorage instance with the 'counts' key" in {
+      val storage = MetricsStorage(
+        Map(ToDo.name -> 5)
+      )
+
+      metricsRepo.reset(storage).futureValue
+
+      metricsRepo.findAll().futureValue.loneElement shouldBe storage
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/workitem/metrics/WorkItemMetricsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/metrics/WorkItemMetricsSpec.scala
@@ -61,9 +61,10 @@ class WorkItemMetricsSpec extends WordSpec
   def updatedRegistryWith(status: ProcessingStatus): Future[Int] = for {
     item <- repo.pushNew(item1, now)
     _ <- repo.markAs(item.id, status)
-    totals <- sequence(metrics.map(_.refresh()))
-  } yield totals.sum
+    totals <- WorkItemGauge.reset(metrics, repo, ???)// sequence(metrics.map(_.refresh()))
+  } yield totals.flatMap {_.counts.get(status.name) }.getOrElse(0) // totals.sum
 
   implicit lazy val metrics = WorkItemGauge.createGauges(repo, metricsRepo, 10 milliseconds)
+
 }
 


### PR DESCRIPTION
Contains several changes to help facilitate the storage of work item repo metrics in a mongo collection:
- Each metric/count is stored individually in the mongo collection (effectively a key-value pair)
- WorkItemGauge now supplies counts directly from the mongo metrics collection and has had the embedded refresh/run logic externalised
- Supports the ability to gather metrics across multiple work item repositories and write to a single collection
