### PR TITLE
DC-530: Pull ToDo items first, Failed second and InProgress last

### DIFF
--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
@@ -114,29 +114,50 @@ abstract class WorkItemRepository[T, ID](collectionName: String,
   private implicit val read = Json.reads[IdList]
 
   def pullOutstanding(failedBefore: DateTime, availableBefore: DateTime)(implicit ec: ExecutionContext): Future[Option[WorkItem[T]]] = {
-    val id = collection.db.command(
-      FindAndModify(
-        collection = collection.name,
-        query = findOutstandingQuery(failedBefore, availableBefore).as[BSONDocument],
-        fields = Some(Json.obj(workItemFields.id -> 1).as[BSONDocument]),
-        modify = Update(setStatusOperation(InProgress, None).as[BSONDocument], fetchNewObject = true)
-      )
-    ).map(_.map(Json.toJson(_).as[IdList]))
 
     def getWorkItem(idList : IdList): Future[Option[WorkItem[T]]] = {
       val document = collection.find(selector = Json.obj(workItemFields.id -> idList._id)).one[BSONDocument]
       document.map(_.map(Json.toJson(_).as[WorkItem[T]]))
     }
+    val id = findNextItemId(failedBefore,availableBefore)
     id.map(_.map(getWorkItem(_))).flatMap(_.getOrElse(Future.successful(None)))
   }
 
-  private def findOutstandingQuery(failedBefore: DateTime, availableBefore: DateTime): JsObject = {
-    Json.obj("$or" -> Seq(
-      Json.obj(workItemFields.status -> ToDo,       workItemFields.availableAt -> Json.obj("$lt" -> availableBefore)),
-      Json.obj(workItemFields.status -> InProgress, workItemFields.updatedAt -> Json.obj("$lt" -> now.minus(inProgressRetryAfter))),
-      Json.obj(workItemFields.status -> Failed,     workItemFields.updatedAt -> Json.obj("$lt" -> failedBefore), workItemFields.availableAt -> Json.obj("$lt" -> availableBefore)),
-      Json.obj(workItemFields.status -> Failed,     workItemFields.updatedAt -> Json.obj("$lt" -> failedBefore), workItemFields.availableAt -> Json.obj("$exists" -> false))
-    ))
+  private def findNextItemId(failedBefore: DateTime, availableBefore: DateTime)(implicit ec: ExecutionContext) : Future[Option[IdList]] = {
+
+    def findNextItemIdByQuery(query: JsObject)(implicit ec: ExecutionContext): Future[Option[IdList]] = {
+      collection.db.command(
+        FindAndModify(
+          collection = collection.name,
+          query = query.as[BSONDocument],
+          fields = Some(Json.obj(workItemFields.id -> 1).as[BSONDocument]),
+          modify = Update(setStatusOperation(InProgress, None).as[BSONDocument], fetchNewObject = true)
+        )
+      ).map(_.map(Json.toJson(_).as[IdList]))
+    }
+
+    def todoQuery(failedBefore: DateTime, availableBefore: DateTime): JsObject = {
+      Json.obj(workItemFields.status -> ToDo,       workItemFields.availableAt -> Json.obj("$lt" -> availableBefore))
+    }
+
+    def failedQuery(failedBefore: DateTime, availableBefore: DateTime): JsObject = {
+      Json.obj("$or" -> Seq(
+        Json.obj(workItemFields.status -> Failed,     workItemFields.updatedAt -> Json.obj("$lt" -> failedBefore), workItemFields.availableAt -> Json.obj("$lt" -> availableBefore)),
+        Json.obj(workItemFields.status -> Failed,     workItemFields.updatedAt -> Json.obj("$lt" -> failedBefore), workItemFields.availableAt -> Json.obj("$exists" -> false))
+      ))
+    }
+
+    def inProgressQuery(failedBefore: DateTime, availableBefore: DateTime): JsObject = {
+      Json.obj(workItemFields.status -> InProgress, workItemFields.updatedAt -> Json.obj("$lt" -> now.minus(inProgressRetryAfter)))
+    }
+
+    findNextItemIdByQuery(todoQuery(failedBefore, availableBefore)).flatMap( item => item match {
+      case Some(_) => Future.successful(item)
+      case None => findNextItemIdByQuery(failedQuery(failedBefore, availableBefore)).flatMap( item2 => item2 match {
+        case Some(value) => Future.successful(item2)
+        case None => findNextItemIdByQuery(inProgressQuery(failedBefore, availableBefore))
+      })
+    })
   }
 
   def markAs(id: ID, status: ProcessingStatus, availableAt: Option[DateTime] = None)(implicit ec: ExecutionContext): Future[Boolean] =


### PR DESCRIPTION
Split WorkItemRepository query into three which are executed one after the other until an item is found. It looks for ToDo items first, then Failed and finally InProgress.
https://jira.tools.tax.service.gov.uk/browse/DC-530
