### PR TITLE
PLATOPS-1226 - Update dependency for simple-reactivemongo

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -34,7 +34,7 @@ object HmrcBuild extends Build {
       targetJvm := "jvm-1.8",
       libraryDependencies ++= Seq(
         "com.typesafe.play" %% "play"                 % PlayVersion.current % "provided",
-        "uk.gov.hmrc"       %% "simple-reactivemongo" % "6.0.0",
+        "uk.gov.hmrc"       %% "simple-reactivemongo" % "6.1.0",
         "uk.gov.hmrc"       %% "mongo-lock"           % "5.0.0",
         "uk.gov.hmrc"       %% "metrix"               % "2.0.0",
         "org.scalatest"     %% "scalatest"            % "2.2.6"             % "test",

--- a/src/main/scala/uk/gov/hmrc/workitem/EnsureIndexDelete.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/EnsureIndexDelete.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/workitem/StatusUpdateResult.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/StatusUpdateResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItem.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItemFieldNames.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItemFieldNames.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItemModuleRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItemModuleRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/WorkItemRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/workitem/status.scala
+++ b/src/main/scala/uk/gov/hmrc/workitem/status.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/workitem/ProcessingStatusSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/ProcessingStatusSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WithWorkItemRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/workitem/WorkItemModuleRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WorkItemModuleRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/workitem/WorkItemRepositorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/workitem/WorkItemRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated simple-reactivemongo dependency to the latest version (removes excessive warnings from the logs).