### PR TITLE
Update scalaVersion to 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ majorVersion                     := 7
 
 defaultSettings()
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.10"
 
 crossScalaVersions  := Seq("2.11.12", "2.12.10")
 


### PR DESCRIPTION
The build will still build for 2.11, on Play26.

This is a workaround for BDOG-824 and BDOG-825